### PR TITLE
Posterior analysis bugfixes

### DIFF
--- a/SOBER/BASQ/_scale_mmlt.py
+++ b/SOBER/BASQ/_scale_mmlt.py
@@ -265,7 +265,10 @@ class ScaleMmltGP(Utils):
         mu_g_x = self.gspace_mean_predict(x)
         mu_g_y = self.gspace_mean_predict(y)
         cov_h_xy = self.hspace_kernel(x, y)
-        CLy = mu_g_x.unsqueeze(1) * mu_g_y.unsqueeze(0) * (cov_h_xy.exp() - 1)
+        if len(cov_h_xy.shape) == 2:
+            CLy = mu_g_x.unsqueeze(1) * mu_g_y.unsqueeze(0) * (cov_h_xy.exp() - 1)
+        elif len(cov_h_xy.shape) == 3:
+            CLy = mu_g_x.unsqueeze(1).unsqueeze(0) * mu_g_y.unsqueeze(1) * (cov_h_xy.exp() - 1)
 
         d = min(len(x), len(y))
         CLy[range(d), range(d)] = CLy[range(d), range(d)] + self.jitter

--- a/SOBER/_sampler.py
+++ b/SOBER/_sampler.py
@@ -408,9 +408,21 @@ class MixtureSampler:
         """
         n_wkde = int(self.ratio_wkde * n_samples)
         n_prior = int((1-self.ratio_wkde) * n_samples)
+
+        tm = TensorManager()
         
-        samples_wkde = self.sober.prior.sample(n_wkde)
-        samples_prior = self.prior.sample(n_prior)
+        if n_wkde:
+            samples_wkde = self.sober.prior.sample(n_wkde)
+        else:
+            samples_wkde = torch.zeros(
+                [0, self.sober.prior.n_dims], dtype=tm.dtype, device=tm.device
+            )
+        if n_prior:
+            samples_prior = self.prior.sample(n_prior)
+        else:
+            samples_prior = torch.zeros(
+                [0, self.sober.prior.n_dims], dtype=tm.dtype, device=tm.device
+            )
         samples = torch.vstack([samples_wkde, samples_prior])
         return samples
     


### PR DESCRIPTION
Fixed two minor issues preventing use of the "NumPy mode" of this library.
 - ScaleMMLT kernel evaluation now correctly handles batched covariance matrices.
 - Cases of "no prior" and "no likelihood" sampling now also work with "NumPy mode".