### PR TITLE
made settings configurable from scripts

### DIFF
--- a/SOBER/__init__.py
+++ b/SOBER/__init__.py
@@ -1,0 +1,3 @@
+from ._settings import setting_parameters
+
+__all__ = ['setting_parameters',]

--- a/SOBER/_settings.py
+++ b/SOBER/_settings.py
@@ -1,12 +1,22 @@
 import torch
 
+_device = (
+    torch.device('cuda')
+    if torch.cuda.is_available()
+    else torch.device('cpu')
+)
+_dtype = torch.double
 
-def setting_parameters():
+
+def setting_parameters(device=None, dtype=None):
     """
     Return:
        - device: torch.device, cpu or cuda
        - dtype: torch.dtype, torch.float or torch.double
     """
-    device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-    dtype = torch.double
-    return device, dtype
+    global _device, _dtype
+    if device:
+        _device = device
+    if dtype:
+        _dtype = dtype
+    return _device, _dtype


### PR DESCRIPTION
To make the library configurable by script, rather than by machine, device and dtype are now global variables and setting_parameters can be used to set them.